### PR TITLE
Upgrade Browserify dep to make grunt-browserify happy. Resolves #125.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-browserify": "~1.2.8",
     "stylus": "~0.38.0",
-    "browserify": "~2.33.1",
+    "browserify": "~2.35.1",
     "grunt-contrib-stylus": "~0.8.0",
     "grunt-nodemon": "~0.1.1",
     "grunt-concurrent": "~0.4.0",


### PR DESCRIPTION
This resolves the `npm install` error I was getting on a fresh clone.

That's as far as I've gotten with my dev env so please try `npm install` and running tests on your end before merging this.
